### PR TITLE
Add project members endpoint, pagination, and parallel fetching

### DIFF
--- a/fabric_ceph/openapi_server/controllers/cluster_user_controller.py
+++ b/fabric_ceph/openapi_server/controllers/cluster_user_controller.py
@@ -59,14 +59,18 @@ def list_users(cluster):  # noqa: E501
     return rc.list_users(cluster)
 
 
-def list_project_members():  # noqa: E501
+def list_project_members(offset=0, limit=50):  # noqa: E501
     """List project members with bastion logins
 
      # noqa: E501
 
+    :param offset: Number of results to skip
+    :type offset: int
+    :param limit: Maximum number of results to return
+    :type limit: int
     :rtype: dict
     """
-    return rc.list_project_members()
+    return rc.list_project_members(offset=offset, limit=limit)
 
 
 def overwrite_user_caps(cluster, body):  # noqa: E501

--- a/fabric_ceph/openapi_server/openapi/openapi.yaml
+++ b/fabric_ceph/openapi_server/openapi/openapi.yaml
@@ -950,6 +950,25 @@ paths:
   /project/members:
     get:
       operationId: list_project_members
+      parameters:
+      - description: Number of results to skip (default 0)
+        explode: true
+        in: query
+        name: offset
+        required: false
+        schema:
+          default: 0
+          type: integer
+        style: form
+      - description: Maximum number of results to return (default 50)
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          default: 50
+          type: integer
+        style: form
       responses:
         "200":
           content:
@@ -970,9 +989,15 @@ paths:
                           type: array
                           items:
                             type: string
+                  limit:
+                    type: integer
+                  offset:
+                    type: integer
                   size:
                     type: integer
                   status:
+                    type: integer
+                  total:
                     type: integer
                   type:
                     type: string

--- a/fabric_ceph/response/cluster_user_controller.py
+++ b/fabric_ceph/response/cluster_user_controller.py
@@ -1,4 +1,5 @@
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List, Any
 
 import connexion
@@ -314,21 +315,33 @@ def list_project_members():  # noqa: E501
                 if mtype:
                     people[uuid].add(mtype)
 
-        # Fetch user info for each unique person and collect bastion_login
+        # Fetch user info in parallel to avoid N+1 timeout
+        def _fetch_member(uuid, mtypes):
+            user_info = core_api.get_user_info(uuid=uuid)
+            bastion_login = user_info.get("bastion_login")
+            if bastion_login:
+                return {
+                    "uuid": uuid,
+                    "bastion_login": bastion_login,
+                    "membership_types": sorted(mtypes),
+                }
+            return None
+
         members = []
-        for uuid, mtypes in people.items():
-            try:
-                user_info = core_api.get_user_info(uuid=uuid)
-                bastion_login = user_info.get("bastion_login")
-                if bastion_login:
-                    members.append({
-                        "uuid": uuid,
-                        "bastion_login": bastion_login,
-                        "membership_types": sorted(mtypes),
-                    })
-            except Exception as e:
-                log.warning(f"Failed to get user info for {uuid}: {e}")
-                continue
+        with ThreadPoolExecutor(max_workers=20) as executor:
+            futures = {
+                executor.submit(_fetch_member, uuid, mtypes): uuid
+                for uuid, mtypes in people.items()
+            }
+            for future in as_completed(futures):
+                uuid = futures[future]
+                try:
+                    result = future.result()
+                    if result:
+                        members.append(result)
+                except Exception as e:
+                    log.warning(f"Failed to get user info for {uuid}: {e}")
+                    continue
 
         # Sort by bastion_login
         members.sort(key=lambda m: m["bastion_login"].lower())

--- a/fabric_ceph/response/cluster_user_controller.py
+++ b/fabric_ceph/response/cluster_user_controller.py
@@ -277,14 +277,15 @@ def list_users(cluster):  # noqa: E501
         log.exception(f"Failed processing CephX list request: {e}")
         return cors_error_response(error=e)
 
-def list_project_members():  # noqa: E501
-    """List project members with bastion logins.
+def list_project_members(offset: int = 0, limit: int = 50):  # noqa: E501
+    """List project members with bastion logins (paginated).
 
     Returns active members of the configured service project who have a bastion_login.
+    Only fetches user details for the requested page to avoid gateway timeouts.
     """
     g = get_globals()
     log = g.log
-    log.debug("Processing list project members request")
+    log.debug(f"Processing list project members request (offset={offset}, limit={limit})")
 
     try:
         fabric_token, is_operator, _ = authorize()
@@ -315,7 +316,14 @@ def list_project_members():  # noqa: E501
                 if mtype:
                     people[uuid].add(mtype)
 
-        # Fetch user info in parallel to avoid N+1 timeout
+        # Sort UUIDs for stable pagination
+        sorted_uuids = sorted(people.keys())
+        total = len(sorted_uuids)
+
+        # Slice to the requested page
+        page_uuids = sorted_uuids[offset:offset + limit]
+
+        # Fetch user info in parallel only for the current page
         def _fetch_member(uuid, mtypes):
             user_info = core_api.get_user_info(uuid=uuid)
             bastion_login = user_info.get("bastion_login")
@@ -330,8 +338,8 @@ def list_project_members():  # noqa: E501
         members = []
         with ThreadPoolExecutor(max_workers=20) as executor:
             futures = {
-                executor.submit(_fetch_member, uuid, mtypes): uuid
-                for uuid, mtypes in people.items()
+                executor.submit(_fetch_member, uuid, people[uuid]): uuid
+                for uuid in page_uuids
             }
             for future in as_completed(futures):
                 uuid = futures[future]
@@ -348,8 +356,11 @@ def list_project_members():  # noqa: E501
 
         body = json.dumps({
             "data": members,
+            "limit": limit,
+            "offset": offset,
             "size": len(members),
             "status": 200,
+            "total": total,
             "type": "project_members",
         })
         return cors_response(req=connexion.request, status_code=200, body=body)


### PR DESCRIPTION
## Summary
- Add `GET /project/members` endpoint for listing project members with bastion logins
- Parallelize user info fetches with ThreadPoolExecutor to fix 504 gateway timeout
- Add offset/limit pagination to `/project/members` for scalable responses
- Filter out Ceph system/infrastructure users from API responses
- Add cookie auth support for PATCH endpoints
- Improve CephFS mount script: install ceph-common, human-friendly path slugs, EL version-based repo selection
- Add `extract_active_users` and `add_users_to_project` utility scripts

## Test plan
- [x] Verify `/project/members` returns paginated results with `total`, `offset`, `limit`
- [x] Verify no 504 timeout with 300+ project members
- [x] Verify `offset` and `limit` query params work correctly
- [x] Verify system users (e.g. `client.admin`) are filtered from CephX user listings
- [x] Verify mount script installs ceph-common and handles both el8/el9