### PR TITLE
Add storage user management tools and role-based project checks

### DIFF
--- a/tools/check_solo_storage_users.py
+++ b/tools/check_solo_storage_users.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+
+"""Find members of the storage project who don't belong to any other active project.
+
+Fetches all members of the storage service project from the Core API,
+then checks each member's other active project memberships. Users whose
+only active project is the storage project are candidates for removal.
+"""
+
+import argparse
+import csv
+import sys
+
+from core_api import CoreApi, CoreApiError
+
+STORAGE_PROJECT_UUID = "6b8dd6eb-4b2b-4656-b3ee-ce61f91a12b4"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find storage project members not in any other active project"
+    )
+    parser.add_argument(
+        "--token-file", required=True,
+        help="Path to JSON file containing id_token"
+    )
+    parser.add_argument(
+        "--core-api-host", default="https://uis.fabric-testbed.net",
+        help="Core API URL (default: https://uis.fabric-testbed.net)"
+    )
+    parser.add_argument(
+        "--storage-project-uuid", default=STORAGE_PROJECT_UUID,
+        help=f"UUID of the storage project (default: {STORAGE_PROJECT_UUID})"
+    )
+    parser.add_argument(
+        "--output", default="solo_storage_users.csv",
+        help="Output CSV for users to remove (default: solo_storage_users.csv)"
+    )
+    args = parser.parse_args()
+
+    try:
+        core = CoreApi(core_api_host=args.core_api_host, token_file=args.token_file)
+    except CoreApiError as e:
+        print(f"Error initializing API: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Fetch the storage project and its members
+    print(f"Fetching storage project {args.storage_project_uuid}...")
+    try:
+        project = core.get_project(args.storage_project_uuid)
+    except CoreApiError as e:
+        print(f"Error fetching project: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    project_name = project.get("name", "Unknown")
+    members = project.get("project_members", [])
+    owners = project.get("project_owners", [])
+    print(f"Project: {project_name}")
+    print(f"Members: {len(members)}, Owners: {len(owners)}")
+
+    # Combine members (skip owners — they manage the project)
+    all_members = []
+    owner_uuids = {o.get("uuid") for o in owners}
+    for m in members:
+        uuid = m.get("uuid")
+        if uuid and uuid not in owner_uuids:
+            all_members.append(m)
+
+    total = len(all_members)
+    print(f"\nChecking {total} non-owner members for other active projects...\n")
+
+    solo_users = []     # only in storage project
+    multi_users = []    # in other active projects too
+    errors = 0
+
+    for i, member in enumerate(all_members, 1):
+        uuid = member.get("uuid") or ""
+        name = member.get("name") or ""
+        email = member.get("email") or ""
+
+        try:
+            # Check all roles: member, creator, owner
+            seen_uuids = set()
+            other_projects = []
+            for role in ("member", "creator", "owner"):
+                try:
+                    projects = core.collect_projects(
+                        person_uuid=uuid, active=True,
+                        extra={"role": role},
+                    )
+                except CoreApiError:
+                    if role == "member":
+                        projects = core.collect_projects(
+                            person_uuid=uuid, active=True,
+                        )
+                    else:
+                        continue
+                for p in projects:
+                    puuid = p.get("uuid")
+                    if puuid and puuid != args.storage_project_uuid and puuid not in seen_uuids:
+                        seen_uuids.add(puuid)
+                        other_projects.append(p)
+
+            if not other_projects:
+                # Fetch bastion_login from detail endpoint
+                bastion_login = ""
+                try:
+                    detail = core.get_person_details(uuid)
+                    bastion_login = detail.get("bastion_login") or ""
+                except CoreApiError:
+                    try:
+                        detail = core.get_person(uuid)
+                        bastion_login = detail.get("bastion_login") or ""
+                    except CoreApiError:
+                        pass
+                member["bastion_login"] = bastion_login
+                solo_users.append(member)
+                print(f"  REMOVE: {name:40s} {email:45s} bastion={bastion_login}")
+            else:
+                multi_users.append(member)
+                other_names = [p.get("name", "?") for p in other_projects]
+                # Only print first few to avoid flooding
+                display = other_names[:3]
+                suffix = f" +{len(other_names)-3} more" if len(other_names) > 3 else ""
+                print(f"  KEEP:   {name:40s} {email:45s} ({len(other_projects)} other: {', '.join(display)}{suffix})")
+
+        except CoreApiError as e:
+            errors += 1
+            print(f"  ERROR:  {name:40s} {email:45s} -> {e}", file=sys.stderr)
+
+        if i % 50 == 0:
+            print(f"\n  ... processed {i}/{total} ({len(solo_users)} to remove so far)\n")
+
+    # Summary
+    print(f"\n{'='*80}")
+    print(f"Storage project: {project_name} ({args.storage_project_uuid})")
+    print(f"Total members checked: {total}")
+    print(f"KEEP   (in other active projects): {len(multi_users)}")
+    print(f"REMOVE (only in storage project):  {len(solo_users)}")
+    print(f"Errors: {errors}")
+
+    if solo_users:
+        print(f"\n--- Users to remove ({len(solo_users)}) ---")
+        for u in solo_users:
+            n = u.get('name') or ''
+            e = u.get('email') or ''
+            b = u.get('bastion_login') or ''
+            print(f"  {n:40s} {e:45s} {b}")
+
+        # Write output CSV
+        fields = ["uuid", "name", "email", "bastion_login"]
+        with open(args.output, "w", newline="") as f:
+            writer = csv.DictWriter(f, fieldnames=fields, extrasaction="ignore")
+            writer.writeheader()
+            for u in solo_users:
+                writer.writerow(u)
+        print(f"\nWrote {len(solo_users)} users to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/core_api.py
+++ b/tools/core_api.py
@@ -348,6 +348,7 @@ class CoreApi:
         sort_by: Optional[str] = None,
         order_by: Optional[str] = None,
         page_limit: int = 200,
+        extra: Optional[Dict[str, Any]] = None,
     ) -> List[dict]:
         """
         Fetch ALL pages of /projects (within the caller's normal scope) and
@@ -358,12 +359,14 @@ class CoreApi:
                 - True  => only active projects
                 - False => only inactive/expired projects
                 - None  => no client-side active filter (return all)
-            search, person_uuid, role, exact_match, include_memberships, tags:
+            search, person_uuid, exact_match:
                 Passed to the server per page (only filters supported by backend are applied server-side).
             sort_by, order_by:
                 Sorting applied server-side per page; we still iterate through all pages.
             page_limit:
                 Page size used for pagination (default 200).
+            extra:
+                Additional query parameters (e.g. {"role": "owner"}).
 
         Returns:
             List[dict]: aggregated projects from all pages, with optional client-side active filtering.
@@ -381,6 +384,7 @@ class CoreApi:
                 exact_match=exact_match,
                 sort_by=sort_by,
                 order_by=order_by,
+                extra=extra,
             )
             results = page.get("results") or []
             all_projects.extend(results)
@@ -570,6 +574,29 @@ class CoreApi:
             "PATCH",
             f"/projects/{project_uuid}/project-members",
             params={"operation": "add"},
+            json_body={"project_members": person_uuids},
+        )
+
+    def remove_members_from_project(
+        self, project_uuid: str, person_uuids: List[str]
+    ) -> None:
+        """
+        Remove one or more people from a project.
+
+        Uses ``PATCH /projects/{uuid}/project-members?operation=remove``.
+
+        :param project_uuid: UUID of the target project.
+        :param person_uuids: List of person UUIDs to remove.
+        :raises CoreApiError: On HTTP or validation errors.
+        """
+        if not project_uuid:
+            raise CoreApiError("project_uuid must be provided.")
+        if not person_uuids:
+            raise CoreApiError("person_uuids must be a non-empty list.")
+        self._request(
+            "PATCH",
+            f"/projects/{project_uuid}/project-members",
+            params={"operation": "remove"},
             json_body={"project_members": person_uuids},
         )
 

--- a/tools/delete_solo_storage_volumes.py
+++ b/tools/delete_solo_storage_volumes.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+
+"""Delete CephFS subvolumes and CephX users for solo-storage users.
+
+Cross-references solo_storage_users.csv (bastion_login) with per-cluster
+user CSVs to determine which cluster each user is on, then calls the
+Ceph Manager API to delete their subvolume and CephX user entity.
+
+Runs in dry-run mode by default — pass --execute to actually delete.
+"""
+
+import argparse
+import csv
+import sys
+from collections import defaultdict
+
+from fabric_ceph_client.fabric_ceph_client import CephManagerClient, ApiError
+
+VOL_NAME = "CEPH-FS-01"
+SUBVOL_GROUP = "fabric_users"
+
+CLUSTERS = [
+    ("east", "Ceph_FABRIC_v3_east", "users_east.csv"),
+    ("west", "Ceph_FABRIC_v3_west", "users_west.csv"),
+    ("europe", "Ceph_FABRIC_v3_europe", "users_europe.csv"),
+    ("asia", "Ceph_FABRIC_v3_asia", "users_asia.csv"),
+]
+
+
+def load_cluster_users(cluster_csv_dir):
+    """Load per-cluster CSVs and return {bastion_login: cluster_name}."""
+    login_to_cluster = {}
+    for cluster_name, subdir, csv_file in CLUSTERS:
+        path = f"{cluster_csv_dir}/{subdir}/{csv_file}"
+        try:
+            with open(path, newline="") as f:
+                for row in csv.DictReader(f):
+                    name = row.get("name", "").strip()
+                    if name:
+                        login_to_cluster[name] = cluster_name
+        except FileNotFoundError:
+            print(f"  Warning: {path} not found, skipping", file=sys.stderr)
+    return login_to_cluster
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Delete CephFS subvolumes and CephX users for solo-storage users"
+    )
+    parser.add_argument(
+        "--token-file", required=True,
+        help="Path to JSON file containing id_token for Ceph Manager API"
+    )
+    parser.add_argument(
+        "--csv-file", default="solo_storage_users.csv",
+        help="CSV file with solo-storage users (default: solo_storage_users.csv)"
+    )
+    parser.add_argument(
+        "--cluster-csv-dir", required=True,
+        help="Directory containing per-cluster subdirs (e.g. ~/claude-jh/ceph)"
+    )
+    parser.add_argument(
+        "--ceph-manager-url", required=True,
+        help="Ceph Manager API base URL (e.g. https://ceph-manager.fabric-testbed.net)"
+    )
+    parser.add_argument(
+        "--vol-name", default=VOL_NAME,
+        help=f"CephFS volume name (default: {VOL_NAME})"
+    )
+    parser.add_argument(
+        "--group-name", default=SUBVOL_GROUP,
+        help=f"CephFS subvolume group (default: {SUBVOL_GROUP})"
+    )
+    parser.add_argument(
+        "--force", action="store_true",
+        help="Force-delete subvolumes even if not empty"
+    )
+    parser.add_argument(
+        "--execute", action="store_true",
+        help="Actually delete. Without this flag, runs in dry-run mode."
+    )
+    args = parser.parse_args()
+
+    # Load solo-storage users
+    solo_users = []
+    with open(args.csv_file, newline="") as f:
+        for row in csv.DictReader(f):
+            solo_users.append(row)
+
+    if not solo_users:
+        print("No users found in CSV file. Nothing to do.")
+        sys.exit(0)
+
+    # Build bastion_login -> cluster mapping from per-cluster CSVs
+    login_to_cluster = load_cluster_users(args.cluster_csv_dir)
+
+    # Match solo users to their clusters
+    by_cluster = defaultdict(list)
+    not_found = []
+    for user in solo_users:
+        bastion = user.get("bastion_login", "").strip()
+        if not bastion:
+            continue
+        cluster = login_to_cluster.get(bastion)
+        if cluster:
+            by_cluster[cluster].append(user)
+        else:
+            not_found.append(user)
+
+    # Summary
+    print(f"Solo-storage users: {len(solo_users)}")
+    print(f"Matched to clusters: {sum(len(v) for v in by_cluster.values())}")
+    if not_found:
+        print(f"Not found in any cluster CSV: {len(not_found)}")
+        for u in not_found:
+            print(f"  {u.get('name') or '':40s} {u.get('bastion_login') or ''}")
+
+    for cluster_name in ["east", "west", "europe", "asia"]:
+        users = by_cluster.get(cluster_name, [])
+        print(f"\n  {cluster_name}: {len(users)} users")
+
+    if not args.execute:
+        print(f"\n[DRY RUN] Would delete the following subvolumes and CephX users:\n")
+        for cluster_name in ["east", "west", "europe", "asia"]:
+            users = by_cluster.get(cluster_name, [])
+            if not users:
+                continue
+            print(f"  --- {cluster_name} ({len(users)} users) ---")
+            for u in users:
+                bastion = u.get("bastion_login") or ""
+                name = u.get("name") or ""
+                print(f"    subvolume: {args.vol_name}/{args.group_name}/{bastion}  "
+                      f"entity: client.{bastion}  ({name})")
+        print(f"\n[DRY RUN] Re-run with --execute to actually delete them.")
+        sys.exit(0)
+
+    # Initialize Ceph Manager client
+    client = CephManagerClient(
+        base_url=args.ceph_manager_url,
+        token_file=args.token_file,
+    )
+
+    deleted_subvols = 0
+    deleted_users = 0
+    failed = 0
+
+    for cluster_name in ["east", "west", "europe", "asia"]:
+        users = by_cluster.get(cluster_name, [])
+        if not users:
+            continue
+
+        print(f"\n--- {cluster_name}: deleting {len(users)} users ---")
+        for i, u in enumerate(users, 1):
+            bastion = u.get("bastion_login") or ""
+            name = u.get("name") or ""
+            entity = f"client.{bastion}"
+
+            # Delete subvolume
+            try:
+                client.delete_subvolume(
+                    cluster=cluster_name,
+                    vol_name=args.vol_name,
+                    subvol_name=bastion,
+                    group_name=args.group_name,
+                    force=args.force,
+                )
+                deleted_subvols += 1
+                print(f"  [{i}/{len(users)}] Deleted subvolume: {bastion}")
+            except ApiError as e:
+                if e.status == 404:
+                    print(f"  [{i}/{len(users)}] Subvolume not found (already deleted?): {bastion}")
+                else:
+                    failed += 1
+                    print(f"  [{i}/{len(users)}] Failed to delete subvolume {bastion}: {e}",
+                          file=sys.stderr)
+
+            # Delete CephX user
+            try:
+                client.delete_user(cluster=cluster_name, entity=entity)
+                deleted_users += 1
+                print(f"  [{i}/{len(users)}] Deleted CephX user: {entity}")
+            except ApiError as e:
+                if e.status == 404:
+                    print(f"  [{i}/{len(users)}] CephX user not found (already deleted?): {entity}")
+                else:
+                    failed += 1
+                    print(f"  [{i}/{len(users)}] Failed to delete CephX user {entity}: {e}",
+                          file=sys.stderr)
+
+    print(f"\nDone. Deleted subvolumes: {deleted_subvols}, Deleted CephX users: {deleted_users}, "
+          f"Failed: {failed}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/extract_active_users.py
+++ b/tools/extract_active_users.py
@@ -5,12 +5,17 @@
 #
 # Author: Komal Thareja (kthare10@renci.org)
 
-"""Extract all active FABRIC users to a CSV file.
+"""Extract active FABRIC users who belong to at least one active project
+(other than the FABRIC Ceph storage service project) to a CSV file.
 
 The /people list endpoint only returns (uuid, name, email), so this script
 fetches the enriched detail record for each user from the core-api-metrics
 endpoint to obtain ``bastion_login``, ``active`` status, and ``last_updated``
 timestamp.  Users who have not been updated in over a year are excluded.
+Users whose only active project is the Ceph storage project are excluded.
+
+A user qualifies if they are a member, owner, or creator of at least one
+active project other than the Ceph storage project.
 """
 
 import argparse
@@ -20,10 +25,12 @@ import sys
 
 from core_api import CoreApi, CoreApiError, _parse_possible_timestamp
 
+STORAGE_PROJECT_UUID = "6b8dd6eb-4b2b-4656-b3ee-ce61f91a12b4"
+
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Extract active FABRIC users to CSV"
+        description="Extract active FABRIC users (with non-storage project membership) to CSV"
     )
     parser.add_argument(
         "--token-file", required=True,
@@ -40,6 +47,10 @@ def main():
     parser.add_argument(
         "--inactive-days", type=int, default=365,
         help="Exclude users not updated in this many days (default: 365)"
+    )
+    parser.add_argument(
+        "--storage-project-uuid", default=STORAGE_PROJECT_UUID,
+        help=f"UUID of the Ceph storage project to exclude (default: {STORAGE_PROJECT_UUID})"
     )
     args = parser.parse_args()
 
@@ -66,6 +77,7 @@ def main():
     active_users = []
     skipped_inactive = 0
     skipped_stale = 0
+    skipped_no_project = 0
 
     for i, person in enumerate(people, 1):
         uuid = person.get("uuid")
@@ -98,6 +110,43 @@ def main():
                 print(f"  Processed {i}/{total}...")
             continue
 
+        # Must be a member, owner, or creator of at least one active project
+        # other than the storage project
+        try:
+            seen_uuids = set()
+            other_projects = []
+            for role in ("member", "creator", "owner"):
+                try:
+                    projects = core.collect_projects(
+                        person_uuid=uuid, active=True,
+                        extra={"role": role},
+                    )
+                except CoreApiError:
+                    # Some API versions may not support role filter; fall back
+                    if role == "member":
+                        projects = core.collect_projects(
+                            person_uuid=uuid, active=True,
+                        )
+                    else:
+                        continue
+                for p in projects:
+                    puuid = p.get("uuid")
+                    if puuid and puuid != args.storage_project_uuid and puuid not in seen_uuids:
+                        seen_uuids.add(puuid)
+                        other_projects.append(p)
+            if not other_projects:
+                skipped_no_project += 1
+                name = detail.get("name") or ""
+                email = detail.get("email") or ""
+                print(f"  Skipping {name} ({email}) — no active project besides Ceph storage")
+                if i % 100 == 0 or i == total:
+                    print(f"  Processed {i}/{total}...")
+                continue
+        except CoreApiError as e:
+            # If we can't check projects, include the user to be safe
+            print(f"  Warning: could not check projects for {uuid}: {e}",
+                  file=sys.stderr)
+
         active_users.append(detail)
 
         if i % 100 == 0 or i == total:
@@ -110,7 +159,8 @@ def main():
             writer.writerow(user)
 
     print(f"\nWrote {len(active_users)} active users to {args.output}")
-    print(f"Skipped: {skipped_inactive} inactive, {skipped_stale} not updated in {args.inactive_days}+ days")
+    print(f"Skipped: {skipped_inactive} inactive, {skipped_stale} stale (>{args.inactive_days} days), "
+          f"{skipped_no_project} no active project besides Ceph storage")
 
 
 if __name__ == "__main__":

--- a/tools/list_provisioned_volumes.py
+++ b/tools/list_provisioned_volumes.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+
+"""List provisioned CephFS subvolumes and CephX users across all clusters.
+
+Queries the Ceph Manager API for each cluster and reports:
+  - Number of subvolumes per cluster (in the specified group)
+  - Number of CephX users per cluster
+  - Total across all clusters
+"""
+
+import argparse
+import sys
+
+from fabric_ceph_client.fabric_ceph_client import CephManagerClient, ApiError
+
+VOL_NAME = "CEPH-FS-01"
+SUBVOL_GROUP = "fabric_users"
+CLUSTERS = ["east", "west", "europe", "asia"]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List provisioned CephFS subvolumes and CephX users across clusters"
+    )
+    parser.add_argument(
+        "--token-file", required=True,
+        help="Path to JSON file containing id_token for Ceph Manager API"
+    )
+    parser.add_argument(
+        "--ceph-manager-url", required=True,
+        help="Ceph Manager API base URL"
+    )
+    parser.add_argument(
+        "--vol-name", default=VOL_NAME,
+        help=f"CephFS volume name (default: {VOL_NAME})"
+    )
+    parser.add_argument(
+        "--group-name", default=SUBVOL_GROUP,
+        help=f"CephFS subvolume group (default: {SUBVOL_GROUP})"
+    )
+    parser.add_argument(
+        "--clusters", nargs="+", default=CLUSTERS,
+        help=f"Clusters to query (default: {' '.join(CLUSTERS)})"
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="List individual subvolume and user names"
+    )
+    args = parser.parse_args()
+
+    client = CephManagerClient(
+        base_url=args.ceph_manager_url,
+        token_file=args.token_file,
+    )
+
+    total_subvols = 0
+    total_users = 0
+
+    for cluster in args.clusters:
+        print(f"\n{'='*60}")
+        print(f"Cluster: {cluster}")
+        print(f"{'='*60}")
+
+        # List subvolumes
+        subvol_names = []
+        try:
+            result = client.list_subvolumes(
+                cluster=cluster,
+                vol_name=args.vol_name,
+                group_name=args.group_name,
+            )
+            subvol_names = result.get("data") or result.get("results") or []
+            if isinstance(subvol_names, list) and subvol_names and isinstance(subvol_names[0], dict):
+                subvol_names = [s.get("name") or s.get("subvol_name") or str(s) for s in subvol_names]
+            print(f"  Subvolumes ({args.vol_name}/{args.group_name}): {len(subvol_names)}")
+            if args.verbose and subvol_names:
+                for name in sorted(subvol_names):
+                    print(f"    {name}")
+        except ApiError as e:
+            print(f"  Subvolumes: ERROR - {e}", file=sys.stderr)
+
+        # List CephX users
+        user_names = []
+        try:
+            result = client.list_users(cluster=cluster)
+            user_names = result.get("data") or result.get("results") or []
+            if isinstance(user_names, list) and user_names and isinstance(user_names[0], dict):
+                user_names = [u.get("entity") or u.get("name") or str(u) for u in user_names]
+            print(f"  CephX users: {len(user_names)}")
+            if args.verbose and user_names:
+                for name in sorted(user_names):
+                    print(f"    {name}")
+        except ApiError as e:
+            print(f"  CephX users: ERROR - {e}", file=sys.stderr)
+
+        total_subvols += len(subvol_names)
+        total_users += len(user_names)
+
+    print(f"\n{'='*60}")
+    print(f"TOTAL across {len(args.clusters)} clusters:")
+    print(f"  Subvolumes: {total_subvols}")
+    print(f"  CephX users: {total_users}")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/remove_solo_storage_users.py
+++ b/tools/remove_solo_storage_users.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# MIT License
+#
+# Copyright (c) 2020 FABRIC Testbed
+#
+# Author: Komal Thareja (kthare10@renci.org)
+
+"""Remove users from the storage project who don't belong to any other active project.
+
+Reads user UUIDs from solo_storage_users.csv (produced by
+check_solo_storage_users.py) and removes them from the storage project.
+Runs in dry-run mode by default — pass --execute to actually remove.
+"""
+
+import argparse
+import csv
+import sys
+
+from core_api import CoreApi, CoreApiError
+
+STORAGE_PROJECT_UUID = "6b8dd6eb-4b2b-4656-b3ee-ce61f91a12b4"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Remove solo-storage users from the storage project"
+    )
+    parser.add_argument(
+        "--token-file", required=True,
+        help="Path to JSON file containing id_token"
+    )
+    parser.add_argument(
+        "--csv-file", default="solo_storage_users.csv",
+        help="CSV file with users to remove (default: solo_storage_users.csv)"
+    )
+    parser.add_argument(
+        "--core-api-host", default="https://uis.fabric-testbed.net",
+        help="Core API URL (default: https://uis.fabric-testbed.net)"
+    )
+    parser.add_argument(
+        "--storage-project-uuid", default=STORAGE_PROJECT_UUID,
+        help=f"UUID of the storage project (default: {STORAGE_PROJECT_UUID})"
+    )
+    parser.add_argument(
+        "--batch-size", type=int, default=25,
+        help="Number of users to remove per API call (default: 25)"
+    )
+    parser.add_argument(
+        "--execute", action="store_true",
+        help="Actually remove users. Without this flag, runs in dry-run mode."
+    )
+    args = parser.parse_args()
+
+    try:
+        core = CoreApi(core_api_host=args.core_api_host, token_file=args.token_file)
+    except CoreApiError as e:
+        print(f"Error initializing API: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Load users from CSV
+    users = []
+    with open(args.csv_file, newline="") as f:
+        for row in csv.DictReader(f):
+            users.append(row)
+
+    if not users:
+        print("No users found in CSV file. Nothing to do.")
+        sys.exit(0)
+
+    # Verify the project
+    try:
+        project = core.get_project(args.storage_project_uuid)
+        project_name = project.get("name") or "Unknown"
+    except CoreApiError as e:
+        print(f"Error fetching project: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Project: {project_name} ({args.storage_project_uuid})")
+    print(f"Users to remove: {len(users)}")
+
+    if not args.execute:
+        print(f"\n[DRY RUN] Would remove the following {len(users)} users:\n")
+        for u in users:
+            name = u.get("name") or ""
+            email = u.get("email") or ""
+            bastion = u.get("bastion_login") or ""
+            print(f"  {name:40s} {email:45s} {bastion}")
+        print(f"\n[DRY RUN] Re-run with --execute to actually remove them.")
+        sys.exit(0)
+
+    # Remove in batches
+    removed = 0
+    failed = 0
+    for i in range(0, len(users), args.batch_size):
+        batch = users[i:i + args.batch_size]
+        batch_uuids = [u["uuid"] for u in batch]
+        try:
+            core.remove_members_from_project(args.storage_project_uuid, batch_uuids)
+            removed += len(batch)
+            print(f"  Removed batch {i // args.batch_size + 1}: "
+                  f"{len(batch)} users ({removed}/{len(users)} total)")
+        except CoreApiError as e:
+            print(f"  Batch failed: {e}", file=sys.stderr)
+            print(f"  Falling back to individual removes...")
+            for u in batch:
+                name = u.get("name") or ""
+                try:
+                    core.remove_members_from_project(
+                        args.storage_project_uuid, [u["uuid"]]
+                    )
+                    removed += 1
+                    print(f"    Removed: {name}")
+                except CoreApiError as e2:
+                    failed += 1
+                    print(f"    Failed:  {name} ({u['uuid']}): {e2}",
+                          file=sys.stderr)
+
+    print(f"\nDone. Removed: {removed}, Failed: {failed}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add scripts to identify, remove, and clean up storage-only users across Ceph clusters
- Update project membership checks to consider all roles (member/creator/owner), not just member
- Add `extra` parameter to `core_api.collect_projects()` for role-based filtering
- Add `remove_members_from_project()` to `core_api.py`

### New scripts
| Script | Purpose |
|--------|---------|
| `check_solo_storage_users.py` | Find Ceph project members not in any other active project |
| `remove_solo_storage_users.py` | Remove solo users from storage project (dry-run default) |
| `delete_solo_storage_volumes.py` | Delete CephFS subvolumes and CephX users via Ceph Manager API (dry-run default) |
| `list_provisioned_volumes.py` | List provisioned subvolumes and CephX users across all clusters |

All destructive scripts run in **dry-run mode by default** and require `--execute` to apply changes.

## Test plan
- [x] Run `check_solo_storage_users.py` with a valid token and verify output CSV
- [x] Run `list_provisioned_volumes.py` against each cluster and verify counts
- [x] Run `remove_solo_storage_users.py` in dry-run mode and verify listed users
- [x] Run `delete_solo_storage_volumes.py` in dry-run mode and verify cross-referencing
- [x] Verify role-based project checks (member/creator/owner) in `extract_active_users.py`